### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,14 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
+    "scikit-learn",
+    "nltk",
+    "sentence-transformers",
+    "transformers",
+    "torch",
+    "pm4py",
+    "pandas",
+    "python-docx",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- list project dependencies in pyproject

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for frappe, sentence_transformers)*

------
https://chatgpt.com/codex/tasks/task_e_6888281558c4832888a0e90f0b8cc282